### PR TITLE
Learn more のクリックエリアの制限

### DIFF
--- a/frontend/components/moleculs/FunctionsPresens.tsx
+++ b/frontend/components/moleculs/FunctionsPresens.tsx
@@ -43,7 +43,7 @@ const ItemCard = ({ item, isFocus }: { item: Item; isFocus: boolean }) => {
         <Grid item xs={2} style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
           <Avatar src={item.icon} />
         </Grid>
-        <Grid item xs={10}>
+        <Grid item xs={10} style={{ display: 'flex', flexDirection: 'column', alignItems: 'start' }}>
           <Typography variant="body1" color="Highlight" fontWeight="bold" align="left" gutterBottom>
             {item.title}
           </Typography>


### PR DESCRIPTION
Learn more のテキストの右部分をクリックした際もLinkタグによりページ遷移が発生していたため、
表示パネルを変更しようとした際にドキュメントページへと移動することがあるため、クリック可能エリアを制限

Before
![image](https://user-images.githubusercontent.com/58153817/203081763-c8d4aa96-ca08-44e8-8311-6a84525e22c7.png)

![image](https://user-images.githubusercontent.com/58153817/203081215-b98eb0e8-9fc3-4446-94a3-a8ac85895114.png)

After
![image](https://user-images.githubusercontent.com/58153817/203081657-f40dd47a-f892-4de4-ba65-8d46a144ade7.png)
